### PR TITLE
added types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+import { AxiosRequestConfig, AxiosPromise } from 'axios';
+
+export default function fetchAdapter(config: AxiosRequestConfig): AxiosPromise;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Fetch adapter for axios",
     "main": "index.js",
     "module": "index.js",
+    "types": "index.d.ts",
     "scripts": {
         "release": "np",
         "test": "echo done",


### PR DESCRIPTION
since there are no types mentioned. the use of library in typescript project gives following error

```
Could not find a declaration file for module '@vespaiach/axios-fetch-adapter'. 
'<project-path>/node_modules/@vespaiach/axios-fetch-adapter/index.js' implicitly has an 'any' type.
Try `npm i --save-dev @types/vespaiach__axios-fetch-adapter` if it exists 
or add a new declaration (.d.ts) file containing `declare module '@vespaiach/axios-fetch-adapter';`
```