### PR TITLE
Map response headers to plain object

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function getResponse(request, config) {
         ok: stageOne.ok,
         status: stageOne.status,
         statusText: stageOne.statusText,
-        headers: new Headers(stageOne.headers), // Make a copy of headers
+        headers: Object.fromEntries(stageOne.headers.entries()),
         config: config,
         request,
     };


### PR DESCRIPTION
Seems like axios returns a plain object of the response headers, whereas fetch returns a `Headers` object, that needs to be mapped accordingly.